### PR TITLE
Use ejabberd default max stanza size

### DIFF
--- a/opensrf/ejabberd-config.yml
+++ b/opensrf/ejabberd-config.yml
@@ -122,7 +122,7 @@ listen:
     protocol_options:
       - "no_sslv3"
     ##   - "no_tlsv1"
-    max_stanza_size: 2000000
+    max_stanza_size: 65536
     shaper: c2s_shaper
     access: c2s
     zlib: true


### PR DESCRIPTION
Now that OpenSRF handles use of the default max_stanza_size for ejabberd, let's go to use that option in our sample default config file.