### PR TITLE
Generate the nginx ssl_dhparam key first, then restart nginx

### DIFF
--- a/extras/nginx.yml
+++ b/extras/nginx.yml
@@ -71,11 +71,11 @@
   file:
     state: absent
     dest: /etc/nginx/sites-enabled/default
-- name: Restart NGINX With New Config
-  become: true
-  service: name=nginx state=restarted
 - name: Generate NGINX ssl_dhparam key
   become: true
   shell: openssl dhparam -out /etc/apache2/ssl/dhparam.pem 2048
+- name: Restart NGINX With New Config
+  become: true
+  service: name=nginx state=restarted
 
 


### PR DESCRIPTION
With the new security requirements for nginx and OpenSRF, we need to generate
the key first, and then restart nginx with the new config. Moving the step up one
should accommodate this change.

Signed-off-by: Ben Shum <ben@evergreener.net>