### PR TITLE
Avoid deprecation warnings for CONDITIONAL_BARE_VARS

### DIFF
--- a/evergreen/database.yml
+++ b/evergreen/database.yml
@@ -38,7 +38,7 @@
     --database {{database_database}} 
     --admin-user {{eg_admin_user}} 
     --admin-pass {{eg_admin_pass}}
-  when: create_schema 
+  when: create_schema | bool
 - block:
   - name: Install PGTAP
     become: true
@@ -48,5 +48,5 @@
     become_user: postgres
     postgresql_ext: name=pgtap db={{database_database}}
   when: 
-    - create_schema
-    - install_pgtap
+    - create_schema | bool
+    - install_pgtap | bool

--- a/evergreen/main.yml
+++ b/evergreen/main.yml
@@ -14,7 +14,7 @@
   include: apache.yml
 - name: Install Database
   include: database.yml
-  when: install_database
+  when: install_database | bool
 - name: Setup translations
   include: setup-translations.yml
   when: locale is defined

--- a/extras/main.yml
+++ b/extras/main.yml
@@ -1,11 +1,11 @@
 - name: Setup Rsyslog
   include: rsyslog.yml
-  when: use_rsyslog
+  when: use_rsyslog | bool
 - name: Install Nginx
   include: nginx.yml
-  when: use_nginx
+  when: use_nginx | bool
 - name: Install Service Files
   include: services.yml
 - name: Starting Services
   include: start.yml
-  when: start_services
+  when: start_services | bool

--- a/extras/nginx.yml
+++ b/extras/nginx.yml
@@ -51,21 +51,21 @@
     dest: /etc/nginx/sites-available/osrf-ws-http-proxy
     regexp: 'proxy_pass https://localhost:7682;'
     replace: 'proxy_pass http://localhost:7682;'
-  when: use_service_websocketd
+  when: use_service_websocketd | bool
 - name: Change NGINX Config to support websocketd (set proxy_send_timeout)
   become: true
   replace:
     dest: /etc/nginx/sites-available/osrf-ws-http-proxy
     regexp: 'proxy_send_timeout 1h;'
     replace: 'proxy_send_timeout 5m;'
-  when: use_service_websocketd
+  when: use_service_websocketd | bool
 - name: Change NGINX Config to support websocketd (set proxy_read_timeout)
   become: true
   replace:
     dest: /etc/nginx/sites-available/osrf-ws-http-proxy
     regexp: 'proxy_read_timeout 1h;'
     replace: 'proxy_read_timeout 5m;'
-  when: use_service_websocketd
+  when: use_service_websocketd | bool
 - name: Remove Default NGINX Site
   become: true
   file:

--- a/extras/rsyslog.yml
+++ b/extras/rsyslog.yml
@@ -1,13 +1,13 @@
 - name: Configure Rsyslog
   become: true
-  when: use_rsyslog
+  when: use_rsyslog | bool
   copy:
     remote_src: true
     src: "{{repo_base}}/Evergreen/Open-ILS/examples/evergreen-rsyslog.conf"
     dest: /etc/rsyslog.d/evergreen.conf
 - name: Restart Rsyslog
   become: true
-  when: use_rsyslog
+  when: use_rsyslog | bool
   service: name=rsyslog state=restarted
 - name: Update opensrf_core.xml for rsyslog
   become: true

--- a/extras/services.yml
+++ b/extras/services.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  when: use_service_opensrf
+  when: use_service_opensrf | bool
 - name: Install OpenSRF Websocketd Service File
   become: true
   template: 
@@ -15,7 +15,7 @@
     owner: root
     group: root
     mode: 0644
-  when: use_service_websocketd
+  when: use_service_websocketd | bool
 - name: Install Evergreen Reporter Service File
   become: true
   template: 
@@ -24,20 +24,20 @@
     owner: root
     group: root
     mode: 0644
-  when: use_service_reporter
+  when: use_service_reporter | bool
 - name: Reload Systemd Configs
   become: true
   shell: systemctl daemon-reload
 - name: Enable OpenSRF Service
   become: true
   shell: systemctl enable opensrf
-  when: use_service_opensrf
+  when: use_service_opensrf | bool
 - name: Enable OpenSRF Websocketd Service
   become: true
   shell: systemctl enable websocketd-osrf
-  when: use_service_websocketd
+  when: use_service_websocketd | bool
 - name: Enable Evergreen Reporter Service
   become: true
   shell: systemctl enable evergreen-reporter
-  when: use_service_reporter
+  when: use_service_reporter | bool
 

--- a/extras/start.yml
+++ b/extras/start.yml
@@ -4,12 +4,12 @@
   environment:
     PATH: "{{ansible_env.PATH}}:{{eg_install_path}}/bin"
   shell: osrf_control --localhost --restart-all
-  when: not use_service_opensrf
+  when: not use_service_opensrf | bool
 - name: Starting Services (systemd)
   become: true
 # NOTE: ansible 2.2 adds a service: use=systemd flag
   shell: systemctl restart opensrf.service
-  when: use_service_opensrf
+  when: use_service_opensrf | bool
 - name: Giving Services Time To Start...
   pause: seconds=10
 - name: Running Autogen
@@ -24,4 +24,4 @@
 - name: Starting Websockets
   become: true
   shell: systemctl restart websocketd-osrf
-  when: use_service_websocketd
+  when: use_service_websocketd | bool

--- a/opensrf/opensrf.yml
+++ b/opensrf/opensrf.yml
@@ -17,7 +17,7 @@
 - name: Apply Proxy JS Websockets Port
   set_fact:
     osrf_ws_port: --with-websockets-port=443
-  when: use_nginx
+  when: use_nginx | bool
 - name: Build OpenSRF
   environment:
     PATH: "{{ansible_env.PATH}}:{{eg_install_path}}/bin"


### PR DESCRIPTION
According to the deprecation warning like:

[DEPRECATION WARNING]: evaluating start_services as a bare variable, this
behaviour will go away and you might need to add |bool to the expression in the
 future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature
will be removed in version 2.12. Deprecation warnings can be disabled by
setting deprecation_warnings=False in ansible.cfg.

Therefore end all when tests with | bool

Signed-off-by: Ben Shum <ben@evergreener.net>