### PR TITLE
Allow storing overrides in ignored file local_settings.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+local_*.yml

--- a/README.adoc
+++ b/README.adoc
@@ -53,8 +53,9 @@ Main playbook.  It organizes the tasks.
 
 === settings.yml
 
-Installation settings.  Modify as needed or override via -e var=val 
-ansible command line option.
+Installation settings.  Modify as needed, override via -e var=val
+ansible command line option, or store multiple overrides in a file
+local_settings.yml and override via -e @local_settings.yml.
 
 === */main.yml
 


### PR DESCRIPTION
This permits you to store local settings for reuse without your
clone appearing dirty, and without interfering in future
pull requests.