### PR TITLE
Use perform_git_checkout: false to disable checkout

### DIFF
--- a/evergreen/eg-build.yml
+++ b/evergreen/eg-build.yml
@@ -7,7 +7,8 @@
     force: "{{force_git_checkout}}"
   become: true
   become_user: opensrf
-  
+  when: perform_git_checkout
+
 - name: Install Evergreen Prereqs
   become: true
   shell: >

--- a/opensrf/opensrf.yml
+++ b/opensrf/opensrf.yml
@@ -7,7 +7,8 @@
     force: "{{force_git_checkout}}"
   become: true
   become_user: opensrf
-  
+  when: perform_git_checkout
+
 - name: Install OpenSRF Prereqs
   become: true
   shell: >

--- a/settings.yml
+++ b/settings.yml
@@ -11,6 +11,7 @@ websocketd_url: https://github.com/joewalnes/websocketd/releases/download/v{{web
 osrf_git_branch: master
 eg_git_branch: master
 
+perform_git_checkout: yes
 # 'no'  == build will fail on local changes
 # 'yes' == local changes will be destroyed
 force_git_checkout: no


### PR DESCRIPTION
With this PR, you can add `perform_git_checkout: false` to `local_settings.yml` and the installer will skip the git checkout phase.  This allows me to iterate on changes in opensrf or evergreen without pushing them.