### PR TITLE
Skip running CPAN tests when installing prerequisites

### DIFF
--- a/evergreen/database.yml
+++ b/evergreen/database.yml
@@ -8,7 +8,7 @@
   become: true
   shell: >
     cd {{repo_base}}/Evergreen 
-    && PERL_MM_USE_DEFAULT=1 make -f 
+    && PERL_MM_USE_DEFAULT=1 NO_CPAN_TEST=1 make -f
     Open-ILS/src/extras/Makefile.install {{pg_install_target}}
 - name: Start Postgres
   become: true

--- a/evergreen/eg-build.yml
+++ b/evergreen/eg-build.yml
@@ -13,7 +13,7 @@
   become: true
   shell: >
     cd {{repo_base}}/Evergreen 
-    && PERL_MM_USE_DEFAULT=1 make -f 
+    && PERL_MM_USE_DEFAULT=1 NO_CPAN_TEST=1 make -f
     Open-ILS/src/extras/Makefile.install {{os_build_target}}
 - name: Set ownership of {{repo_base}} to {{deploy_user}}
   become: true

--- a/evergreen/eg-translator.yml
+++ b/evergreen/eg-translator.yml
@@ -2,7 +2,7 @@
   become: true
   shell: >
     cd {{repo_base}}/Evergreen
-    && PERL_MM_USE_DEFAULT=1 make -f 
+    && PERL_MM_USE_DEFAULT=1 NO_CPAN_TEST=1 make -f
     Open-ILS/src/extras/Makefile.install {{os_build_target}}-translator
 - name: Set ownership of {{repo_base}} to {{deploy_user}}
   become: true

--- a/evergreen/eg-web.yml
+++ b/evergreen/eg-web.yml
@@ -2,7 +2,7 @@
   become: true
   shell: >
     cd {{repo_base}}/Evergreen
-    && PERL_MM_USE_DEFAULT=1 make -f 
+    && PERL_MM_USE_DEFAULT=1 NO_CPAN_TEST=1 make -f
     Open-ILS/src/extras/Makefile.install {{os_build_target}}-developer
 - name: Set ownership of {{repo_base}} to {{deploy_user}}
   become: true


### PR DESCRIPTION
Before this patch, running the playbook on a fresh Noble VM with all default options took: 18m34.677s

With this patch, on a fresh VM with all default options, it took: 13m47.892s

See https://bugs.launchpad.net/evergreen/+bug/2125838