### PR TITLE
settings1.yml

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -101,7 +101,7 @@ create_schema: true
 
 # set to empty value to avoid loading sample data
 # Only used when create_schema=true
-load_sample_data: --load-all-sample
+load_sample_data:
 
 # Install the PGTAP extension for database unit tests?
 # Requires create_schema=true


### PR DESCRIPTION
Set load_sample_data to empty value to prevent loading sample/demo data.

This follows the recommendation in setting1s.yml comments and ensures a clean installation without test data.